### PR TITLE
fixed player 11 seach ID (goalkeepers)

### DIFF
--- a/src/main/java/com/example/client/controllers/CreateRosterController.java
+++ b/src/main/java/com/example/client/controllers/CreateRosterController.java
@@ -299,7 +299,7 @@ public class CreateRosterController {
                     }
                     break;
                 case "playerCard11":
-                    for (IPlayer player : defenders) {
+                    for (IPlayer player : goalkeepers) {
                         if (player.getId() == roster.getPosition11()) {
                             selectedCardPlayer = player;
                             break;


### PR DESCRIPTION
Discovered a bug where player 11 was seaching for a defender ID and not a goalkeeper. This has now been corrected. Hopefully this will fix the goalkeeper incrementing price issue.